### PR TITLE
fix(secu): use numeric UID in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 
-USER nextjs
+USER 1001
 
 EXPOSE 3000
 


### PR DESCRIPTION
Mettre  l`UID du user en numérique permet à kubernetes d'être sûr qu'on tourne en UID>0